### PR TITLE
feat: add real-time gaze ingestion and WebSocket streaming per session

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,8 @@
 from flask import Flask, request, Response, jsonify
 from flask_cors import CORS
+from flask_socketio import SocketIO, join_room, emit
+from collections import defaultdict
+import time
 
 # Local imports from app
 from app.routes import session as session_route
@@ -9,6 +12,7 @@ from app.routes import session as session_route
 app = Flask(__name__)
 CORS(app)
 
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="threading")
 
 # @app.route('/', methods=['GET'])
 # def welcome():
@@ -77,3 +81,41 @@ def batch_predict():
     if request.method == 'POST':
         return session_route.batch_predict()
     return Response('Invalid request method for route', status=405, mimetype='application/json')
+
+# TODO: replace with persistent storage for replay & analytics
+gaze_buffer = defaultdict(list)
+
+@socketio.on("join_session")
+def handle_join(data):
+    session_id = data.get("session_id")
+    if session_id:
+        join_room(session_id)
+        emit("joined", {"session_id": session_id})
+
+@app.route("/api/session/gaze", methods=["POST"])
+def ingest_gaze():
+    data = request.get_json()
+
+    session_id = data.get("session_id")
+    x = data.get("x")
+    y = data.get("y")
+    timestamp = data.get("timestamp", time.time())
+
+    if not session_id or x is None or y is None:
+        return Response("Invalid payload", status=400)
+
+    point = {
+        "x": x,
+        "y": y,
+        "timestamp": timestamp
+    }
+
+    gaze_buffer[session_id].append(point)
+
+    socketio.emit("gaze_point", point, room=session_id)
+
+    return jsonify({"status": "ok"})
+
+if __name__ == "__main__":
+    socketio.run(app, host="0.0.0.0", port=5000)
+

--- a/app/main.py
+++ b/app/main.py
@@ -88,13 +88,18 @@ gaze_buffer = defaultdict(list)
 @socketio.on("join_session")
 def handle_join(data):
     session_id = data.get("session_id")
+    print("OBSERVER JOIN:", session_id, flush=True)
     if session_id:
         join_room(session_id)
         emit("joined", {"session_id": session_id})
 
+
 @app.route("/api/session/gaze", methods=["POST"])
-def ingest_gaze():
+def receive_gaze():
     data = request.get_json()
+
+    if not data:
+        return Response("Invalid JSON", status=400)
 
     session_id = data.get("session_id")
     x = data.get("x")
@@ -105,13 +110,17 @@ def ingest_gaze():
         return Response("Invalid payload", status=400)
 
     point = {
+        "session_id": session_id,
         "x": x,
         "y": y,
-        "timestamp": timestamp
+        "timestamp": timestamp,
+        "phase": data.get("phase"),
     }
 
-    gaze_buffer[session_id].append(point)
+    print("GAZE:", point, flush=True)
 
+    # store for replay later
+    gaze_buffer[session_id].append(point)
     socketio.emit("gaze_point", point, room=session_id)
 
     return jsonify({"status": "ok"})

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,5 +18,4 @@ tzdata==2025.2
 Werkzeug==3.1.3
 gunicorn==23.0.0
 requests==2.31.0
-flask-socketio
-eventlet
+flask-socketio==5.3.6

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,3 +18,5 @@ tzdata==2025.2
 Werkzeug==3.1.3
 gunicorn==23.0.0
 requests==2.31.0
+flask-socketio
+eventlet


### PR DESCRIPTION
## What this adds
- REST endpoint `POST /api/session/gaze` to ingest live gaze points
- WebSocket broadcasting using Flask-SocketIO
- Session-based rooms so multiple observers can subscribe to the same session
- Real-time push of gaze points to connected observers

## Why this is needed
Currently the API supports calibration and batch prediction, but there is no support for streaming gaze data during live usability sessions.  
This change adds the backend infrastructure required for real-time gaze visualization and future session replay, which is a core part of the GSoC project scope.

## Scope
- Non-breaking, additive change
- Does not modify existing calibration or prediction routes
- Uses in-memory buffering for now (to be replaced with persistent storage during full RUXAILAB integration)

##  Demo

Short demo showing **REST → WebSocket live streaming** using a test observer client:  

https://github.com/user-attachments/assets/682e0e25-716f-47c9-a94a-b11b43636601

## Next steps (planned)
- Connect eye-tracking frontend to stream gaze during sessions
- Integrate observer visualization in RUXAILAB UI
- Persist gaze timeline for replay and analysis
