### PR TITLE
optimized predict() loop using groupby

### DIFF
--- a/app/services/gaze_tracker.py
+++ b/app/services/gaze_tracker.py
@@ -199,29 +199,19 @@ def predict(data, k, model_X, model_Y):
     # Create a dictionary to store the data
     data = {}
 
-    # Iterate over the dataframe and store the data
-    for index, row in df_data.iterrows():
+    # Group once by (True X, True Y) — O(n) instead of O(n²)
+    for (true_x, true_y), group in df_data.groupby("True XY"):
+        outer_key = str(true_x).split(".")[0]
+        inner_key = str(true_y).split(".")[0]
 
-        # Get the outer and inner keys
-        outer_key = str(row["True X"]).split(".")[0]
-        inner_key = str(row["True Y"]).split(".")[0]
-
-        # If the outer key is not in the dictionary, add it
         if outer_key not in data:
             data[outer_key] = {}
 
-        # Add the data to the dictionary
         data[outer_key][inner_key] = {
-            "predicted_x": df_data[
-                (df_data["True X"] == row["True X"])
-                & (df_data["True Y"] == row["True Y"])
-            ]["Predicted X"].values.tolist(),
-            "predicted_y": df_data[
-                (df_data["True X"] == row["True X"])
-                & (df_data["True Y"] == row["True Y"])
-            ]["Predicted Y"].values.tolist(),
-            "PrecisionSD": precision_xy[(row["True X"], row["True Y"])],
-            "Accuracy": accuracy_xy[(row["True X"], row["True Y"])],
+            "predicted_x": group["Predicted X"].values.tolist(),
+            "predicted_y": group["Predicted Y"].values.tolist(),
+            "PrecisionSD": precision_xy[(true_x, true_y)],
+            "Accuracy": accuracy_xy[(true_x, true_y)],
         }
 
     # Centroids of the clusters


### PR DESCRIPTION
## Fixes Issue #74

This PR optimizes the data aggregation step inside `predict()` by removing row-wise DataFrame iteration and repeated filtering operations. The refactor improves performance by processing grouped data in a single pass instead of repeatedly scanning the DataFrame.

## Changes Made

### Replaced

* `df_data.iterrows()` loop
* Per-row DataFrame filtering based on `(True X, True Y)`

### Added

* Single-pass iteration using:

```python
df_data.groupby("True XY")
```

* Direct extraction of grouped predictions:

```python
group["Predicted X"].tolist()
group["Predicted Y"].tolist()
```

* Reuse of existing precomputed metrics:

  * `precision_xy`
  * `accuracy_xy`


## Behavior Verification

* Output dictionary structure remains **unchanged**
* Precision and accuracy values remain **unchanged**
* Filtering of **negative predictions** is still respected
