### PR TITLE
Sanitized file_name and calib_id to prevent path traversal attacks

### DIFF
--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -27,6 +27,21 @@ from app.services import gaze_tracker
 ALLOWED_EXTENSIONS = {"txt", "webm"}
 COLLECTION_NAME = "session"
 
+
+def sanitize_filename(name):
+    """Sanitize a user-provided filename to prevent path traversal attacks.
+
+    Strips directory components and allows only alphanumeric characters,
+    hyphens, underscores, and dots. Raises ValueError if the result is empty.
+    """
+    # Take only the final path component to strip any directory traversal
+    name = os.path.basename(name)
+    # Allow only safe characters
+    name = re.sub(r'[^a-zA-Z0-9_\-.]', '', name)
+    if not name:
+        raise ValueError("Invalid filename")
+    return name
+
 # Initialize Flask app
 app = Flask(__name__)
 
@@ -61,7 +76,7 @@ def convert_nan_to_none(obj):
 
 def calib_results():
     from_ruxailab = json.loads(request.form['from_ruxailab'])
-    file_name = json.loads(request.form['file_name'])
+    file_name = sanitize_filename(json.loads(request.form['file_name']))
     fixed_points = json.loads(request.form['fixed_circle_iris_points'])
     calib_points = json.loads(request.form['calib_circle_iris_points'])
     screen_height = json.loads(request.form['screen_height'])
@@ -159,6 +174,8 @@ def batch_predict():
 
         if not calib_id:
             return Response("Missing calib_id", status=400)
+
+        calib_id = sanitize_filename(calib_id)
 
         base_path = Path().absolute() / "app/services/calib_validation/csv/data"
         calib_csv_path = base_path / f"{calib_id}_fixed_train_data.csv"


### PR DESCRIPTION
Fixes Issue #89 

## Summary
This PR fixes a **path traversal vulnerability** in `app/routes/session.py` where user-supplied inputs (`file_name` and `calib_id`) were directly used to construct file paths without validation.

Both values are now sanitized using `sanitize_filename()` before being used in filesystem operations.

## Security Issue
Previously, `file_name` and `calib_id` were used directly in file paths:

```python
file_path = base_path / file_name
calib_path = calib_dir / calib_id
```

Because these values came directly from user input, an attacker could exploit **path traversal** by submitting values such as:

```
../../etc/cron.d/malicious
```

This could allow writing files outside the intended directory and potentially overwrite sensitive system or application files.

---

## Fix Implemented

A `sanitize_filename()` function is now applied to both `file_name` and `calib_id` before path construction.

The function:
- Removes directory components using `os.path.basename`
- Restricts characters to safe ones:
  - `a-z`
  - `A-Z`
  - `0-9`
  - `-`
  - `_`
  - `.`

## Files Modified

```
app/routes/session.py
```
