### PR TITLE
fix: add matplotlib dependency (fix #29)

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,3 +18,4 @@ tzdata==2025.2
 Werkzeug==3.1.3
 gunicorn==23.0.0
 requests==2.31.0
+matplotlib>=3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ tzdata==2025.2
 Werkzeug==3.1.3
 gunicorn==23.0.0
 requests==2.31.0
+matplotlib>=3.7


### PR DESCRIPTION
## Problem
Project fails due to missing matplotlib dependency.

## Solution
Added matplotlib to requirements.txt.

## Testing
Verified project runs successfully after installing dependencies.

Fixes #29