### PR TITLE
Fix: Issue #95 - Remove duplicate routes and simplify Flask routing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, Response, jsonify
+from flask import Flask, jsonify
 from flask_cors import CORS
 
 # Local imports from app
@@ -9,50 +9,6 @@ from app.routes import session as session_route
 app = Flask(__name__)
 CORS(app)
 
-
-# @app.route('/', methods=['GET'])
-# def welcome():
-#     return Response(f'Welcome to EyeLab!', status=200, mimetype='application/json')
-
-# @app.route('/api/user/sessions', methods=['GET'])
-# def get_user_sessions():
-#     # Get user sessions
-#     if request.method == 'GET':
-#         return session_route.get_user_sessions()
-
-#     return Response('Invalid request method for route', status=405, mimetype='application/json')
-
-# @app.route('/api/session', methods=['GET','POST','PATCH','DELETE'])
-# def session():
-#     # Get by ID
-#     if request.method == 'GET':
-#         return session_route.get_session_by_id()
-
-#     # Create Session
-#     elif request.method == 'POST':
-#         return session_route.create_session()
-
-#     # Delete by ID
-#     elif request.method == 'DELETE':
-#         return session_route.delete_session_by_id()
-
-#     # Update by ID
-#     elif request.method == 'PATCH':
-#         return session_route.update_session_by_id()
-
-#     return Response('Invalid request method for route', status=405, mimetype='application/json')
-
-# @app.route('/api/session/results/record', methods=['GET'])
-# def manage_recording():
-#     if request.method == 'GET':
-#         return session_route.session_results_record()
-#     return Response('Invalid request method for route', status=405, mimetype='application/json')
-
-# @app.route('/api/session/results', methods=['GET'])
-# def manage_results():
-#     if request.method == 'GET':
-#         return session_route.session_results()
-#     return Response('Invalid request method for route', status=405, mimetype='application/json')
 
 @app.route('/api/session/health', methods=['GET'])
 def health_check():
@@ -65,15 +21,10 @@ def calib_validation():
     Validates the calibration request.
 
     Returns:
-        If the request method is 'POST', it calls the `calib_results` function from the `session_route` module.
-        Otherwise, it returns a `Response` object with an error message and status code 405.
+        If the request body is valid, it delegates to session_route.calib_results().
     """
-    if request.method == "POST":
-        return session_route.calib_results()
-    return Response('Invalid request method for route', status=405, mimetype='application/json')
+    return session_route.calib_results()
 
 @app.route('/api/session/batch_predict', methods=['POST'])
 def batch_predict():
-    if request.method == 'POST':
-        return session_route.batch_predict()
-    return Response('Invalid request method for route', status=405, mimetype='application/json')
+    return session_route.batch_predict()

--- a/app/routes/session.py
+++ b/app/routes/session.py
@@ -13,7 +13,7 @@ import pandas as pd
 import traceback
 import re
 import requests
-from flask import Flask, request, Response, send_file, jsonify
+from flask import request, Response, send_file, jsonify
 
 # Local imports from app
 from app.services.storage import save_file_locally
@@ -26,10 +26,6 @@ from app.services import gaze_tracker
 # Constants
 ALLOWED_EXTENSIONS = {"txt", "webm"}
 COLLECTION_NAME = "session"
-
-# Initialize Flask app
-app = Flask(__name__)
-
 
 # Helper function to convert NaN values to None for JSON serialization
 def convert_nan_to_none(obj):


### PR DESCRIPTION
Closes #95

This PR refactors the Flask routing structure to remove duplicate and unused route definitions, ensuring a single clear entry point for the application.

### Changes made:
- Cleaned up app/main.py:
  - Removed commented-out and duplicate route blocks
  - Retained only active and necessary route definitions
  - Simplified route handlers to delegate to session routes

- Updated app/routes/session.py:
  - Removed redundant Flask app initialization
  - Ensured routing logic is properly handled from app/main.py

### Impact:
- No changes to business logic (calibration or prediction)
- Improved code clarity and maintainability
- Reduced redundancy and confusion in routing structure

### Validation:
- Application runs successfully using `flask run`
- All existing endpoints are accessible and working as expected