### PR TITLE
Fix: Renamed "callib_points" to "calib_points" in session.to_dict()

### DIFF
--- a/app/models/session.py
+++ b/app/models/session.py
@@ -59,6 +59,6 @@ class Session:
             "screen_record_url": self.screen_record_url,
             "webcam_record_url": self.webcam_record_url,
             "heatmap_url": self.heatmap_url,
-            "callib_points": self.calib_points,
+            "calib_points": self.calib_points,
             "iris_points": self.iris_points,
         }


### PR DESCRIPTION
- Corrects a typo in Session.to_dict() by renaming "callib_points" to "calib_points", ensuring calibration data is correctly returned to consumers.
